### PR TITLE
Add breakpath test and check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,25 @@ ${TARG}:	${OBJS} ${HFILES}
 	${CC} -c -o $@ ${CFLAGS} $<
 
 clean:
-	rm -f ${TARG} ${OBJS}
+	rm -f ${TARG} ${OBJS} tests/test_breakpath ${TESTOBJS}
+
+TESTCFLAGS = $(CFLAGS) -fcommon
+TESTOBJS = tests/9pfs.o tests/9p.o tests/util.o \
+        tests/lib/strecpy.o tests/lib/convD2M.o tests/lib/convM2D.o \
+        tests/lib/convM2S.o tests/lib/convS2M.o tests/lib/read9pmsg.o \
+        tests/lib/readn.o tests/lib/auth_proxy.o tests/lib/auth_rpc.o \
+        tests/lib/auth_getkey.o
+
+tests/%.o: %.c $(HFILES)
+	@mkdir -p $(dir $@)
+	$(CC) -c -o $@ $(TESTCFLAGS) $<
+
+tests/9pfs.o: 9pfs.c $(HFILES)
+	@mkdir -p $(dir $@)
+	$(CC) -c -o $@ $(TESTCFLAGS) -Dmain=unused_main $<
+
+tests/test_breakpath: tests/test_breakpath.c $(TESTOBJS)
+	$(CC) -o $@ $(TESTOBJS) $< $(LDADD)
+
+check: tests/test_breakpath
+	./tests/test_breakpath

--- a/tests/test_breakpath.c
+++ b/tests/test_breakpath.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <string.h>
+
+char *breakpath(char *);
+
+int main(void)
+{
+    char path[] = "/foo/bar";
+    char *base = breakpath(path);
+
+    if (strcmp(base, "bar") != 0) {
+        fprintf(stderr, "base name wrong: %s\n", base);
+        return 1;
+    }
+    if (strcmp(path, "/foo") != 0) {
+        fprintf(stderr, "dir name wrong: %s\n", path);
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a simple unit test for `breakpath()`
- extend Makefile with `check` target to build and run the tests

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68407eaac6788332bf5a0611d7b1c352